### PR TITLE
encode / decode Links with identity Multibase prefix

### DIFF
--- a/dag_cbor/decoding.py
+++ b/dag_cbor/decoding.py
@@ -273,7 +273,9 @@ def _decode_cid(stream: BufferedIOBase, arg: int) -> Tuple[CID, int]:
         raise CBORDecodingError("Error while decoding CID bytes.") from e
     if not isinstance(cid_bytes, bytes):
         raise DAGCBORDecodingError(f"Expected CID bytes, found data of type {type(cid_bytes)} instead.")
-    return (CID.decode(cid_bytes), num_bytes_read)
+    if not cid_bytes[0] == 0:
+        raise DAGCBORDecodingError(f"CID does not start with the identity Multibase prefix (0x00).")
+    return (CID.decode(cid_bytes[1:]), num_bytes_read)
 
 def _decode_bool_none(stream: BufferedIOBase, arg: int) -> Tuple[Optional[bool], int]:
     if arg == 20:

--- a/dag_cbor/encoding.py
+++ b/dag_cbor/encoding.py
@@ -210,7 +210,7 @@ def _encode_dict(stream: BufferedIOBase, value: Dict[str, Any]) -> int:
 
 def _encode_cid(stream: BufferedIOBase, value: CID) -> int:
     num_bytes_written = _encode_head(stream, 0x6, 42)
-    num_bytes_written += _encode_bytes(stream, bytes(value))
+    num_bytes_written += _encode_bytes(stream, b"\0" + bytes(value))
     return num_bytes_written
 
 def _encode_bool(stream: BufferedIOBase, value: bool) -> int:

--- a/test/test_00_encode_eq_cbor2_encode.py
+++ b/test/test_00_encode_eq_cbor2_encode.py
@@ -103,4 +103,4 @@ def test_cid() -> None:
     test_data = rand_cid(nsamples)
     for i, x in enumerate(test_data):
         error_msg = f"failed at #{i} = {repr(x)}"
-        assert cbor2.dumps(cbor2.CBORTag(42, bytes(x))) == encode(x), error_msg
+        assert cbor2.dumps(cbor2.CBORTag(42, b"\0" + bytes(x))) == encode(x), error_msg

--- a/test/test_02_decode_eq_cbor2_decode.py
+++ b/test/test_02_decode_eq_cbor2_decode.py
@@ -116,4 +116,4 @@ def test_cid() -> None:
         encoded_data = encode(x)
         decoded_data = decode(encoded_data)
         assert isinstance(decoded_data, CID)
-        assert cbor2.CBORTag(42, bytes(decoded_data)) == cbor2.loads(encoded_data), error_msg
+        assert cbor2.CBORTag(42, b"\0" + bytes(decoded_data)) == cbor2.loads(encoded_data), error_msg

--- a/test/test_04_link_coding.py
+++ b/test/test_04_link_coding.py
@@ -1,0 +1,35 @@
+"""
+    Tests on the specifics of DAG-CBOR Link encoding.
+"""
+
+# pylint: disable = global-statement
+
+import cbor2
+
+from dag_cbor import encode, decode
+from dag_cbor.utils import DAGCBORDecodingError
+from dag_cbor.random import rand_cid, options
+
+import pytest
+
+nsamples = 1000
+
+def test_decoding_requires_multibase_prefix() -> None:
+    """
+        Checks that the decoder fails if the identity multibase prefix (0x00) is not
+        present in the DAG-CBOR representation.
+    """
+    test_data = rand_cid(nsamples)
+    for i, x in enumerate(test_data):
+        with pytest.raises(DAGCBORDecodingError):
+            decode(cbor2.dumps(cbor2.CBORTag(42, bytes(x))))
+
+def test_encoding_produces_multibase_prefix() -> None:
+    """
+        Checks that the encoder includes the identity multibase prefix (0x00) in the
+        DAG-CBOR representation.
+    """
+    test_data = rand_cid(nsamples)
+    for i, x in enumerate(test_data):
+        rtdata = cbor2.loads(encode(x))
+        assert rtdata.value[0] == 0


### PR DESCRIPTION
According to the [spec](https://ipld.io/specs/codecs/dag-cbor/spec/#links), CIDs MUST be encoded including the identity Multibase prefix (`0x00`).

This change adds the Multibase prefix in encoding (in order to follow the specs) and requires the Multibase prefix in decoding (in order not to become ambiguous and be in line with the spec).

fixes #1 