### PR TITLE
bug: maps have not been in canonical order

### DIFF
--- a/dag_cbor/decoding.py
+++ b/dag_cbor/decoding.py
@@ -257,7 +257,7 @@ def _decode_dict(stream: BufferedIOBase, length: int,
         raise DAGCBORDecodingError(f"Found only {len(d)} unique keys out of {length} key-value pairs.")
     # check that keys are sorted canonically
     assert len(key_bytes_list) == length
-    sorted_key_bytes_list = sorted(key_bytes_list)
+    sorted_key_bytes_list = sorted(key_bytes_list, key=lambda e: (len(e), e))
     for idx, (k1, k2) in enumerate(zip(key_bytes_list, sorted_key_bytes_list)):
         if k1 != k2:
             exp_idx = sorted_key_bytes_list.index(k1)

--- a/dag_cbor/encoding.py
+++ b/dag_cbor/encoding.py
@@ -198,7 +198,7 @@ def _encode_dict(stream: BufferedIOBase, value: Dict[str, Any]) -> int:
     utf8key_val_pairs = [(k.encode("utf-8", errors="strict"), v)
                          for k, v in value.items()]
     # 1. sort keys canonically:
-    sorted_utf8key_val_pairs = sorted(utf8key_val_pairs, key=lambda i: i[0])
+    sorted_utf8key_val_pairs = sorted(utf8key_val_pairs, key=lambda i: (len(i[0]), i[0]))
     # 2. encode key-value pairs (keys already utf-8 encoded):
     num_bytes_written = _encode_head(stream, 0x5, len(value))
     for utf8k, v in sorted_utf8key_val_pairs:

--- a/dag_cbor/utils.py
+++ b/dag_cbor/utils.py
@@ -59,7 +59,7 @@ def _canonical_order_dict(value: Dict[str, Any]) -> Dict[str, Any]:
     #     raise CBOREncodingError("Strings must be valid utf-8 strings.") from e
     # # as far as I understand, the above should never raise UnicodeError on "utf-8" encoding
     utf8key_key_val_pairs = [(k.encode("utf-8", errors="strict"), k, v) for k, v in value.items()]
-    sorted_utf8key_key_val_pairs = sorted(utf8key_key_val_pairs, key=lambda i: i[0])
+    sorted_utf8key_key_val_pairs = sorted(utf8key_key_val_pairs, key=lambda i: (len(i[0]), i[0]))
     return {k: v for _, k, v in sorted_utf8key_key_val_pairs}
 
 

--- a/test/test_00_encode_eq_cbor2_encode.py
+++ b/test/test_00_encode_eq_cbor2_encode.py
@@ -3,7 +3,7 @@
 """
 # pylint: disable = global-statement
 
-import cbor2.encoder as cbor2 # type: ignore
+import cbor2 # type: ignore
 
 from dag_cbor import encode
 from dag_cbor.random import rand_list, rand_dict, rand_int, rand_bytes, rand_str, rand_bool_none, rand_float, rand_cid, options
@@ -94,6 +94,19 @@ def test_dict() -> None:
         for i, x in enumerate(test_data):
             error_msg = f"failed at #{i} = {repr(x)}"
             assert cbor2.dumps(x) == encode(x), error_msg
+
+
+def test_dict_noncanonical() -> None:
+    """
+        Encodes a dict given in noncanonical order and tests if it is encoded in canonical order.
+        from the specs (https://ipld.io/specs/codecs/dag-cbor/spec/#strictness):
+
+        If two keys have different lengths, the shorter one sorts earlier;
+        If two keys have the same length, the one with the lower value in (byte-wise) lexical order sorts earlier.
+    """
+    test_data = {"bar123": 5, "zap": 7, "abc432": 9}
+    assert list(cbor2.loads(encode(test_data))) == ["zap", "abc432", "bar123"]
+
 
 def test_cid() -> None:
     """

--- a/test/test_01_encode_decode_eq_original.py
+++ b/test/test_01_encode_decode_eq_original.py
@@ -6,6 +6,8 @@
 from dag_cbor import encode, decode
 from dag_cbor.random import rand_list, rand_dict, rand_int, rand_bytes, rand_str, rand_bool_none, rand_float, rand_cid, options
 
+import pytest
+
 nsamples = 1000
 
 def test_int() -> None:
@@ -89,12 +91,13 @@ def test_list() -> None:
         assert x == decode(encode(x)), error_msg
         assert x == decode(encode(x, include_multicodec=True), require_multicodec=True), error_msg
 
-def test_dict() -> None:
+@pytest.mark.parametrize("canonical", [True, False])
+def test_dict(canonical) -> None:
     """
         Encodes random `dict` samples with `dag_cbor.encoding.encode`,
         encodes them with `cbor2.encoder.dumps` and checks that the two encodings match.
     """
-    with options(include_cid=False):
+    with options(include_cid=False, canonical=canonical):
         test_data = rand_dict(nsamples)
     for i, x in enumerate(test_data):
         error_msg = f"failed at #{i} = {repr(x)}"


### PR DESCRIPTION
According to the [spec](https://ipld.io/specs/codecs/dag-cbor/spec/#strictness)

> The keys in every map must be sorted length-first by the byte representation of the string keys, where:
>
>   * If two keys have different lengths, the shorter one sorts earlier;
>   * If two keys have the same length, the one with the lower value in (byte-wise) lexical order sorts earlier.

Previous to this PR, maps have been sorted purely in byte-wise lexical order, which is incorrect if keys are not of equal length.

Previous to this PR, DAG-CBOR which was created using go-ipfs v0.11.0 could not be read using `dag-cbor` (this library).
